### PR TITLE
turn supernodal sptrsv on by default

### DIFF
--- a/cmake/kokkoskernels_features.cmake
+++ b/cmake/kokkoskernels_features.cmake
@@ -10,7 +10,7 @@ endfunction()
 
 KOKKOSKERNELS_ADD_OPTION(
   ENABLE_SUPERNODAL_SPTRSV
-  OFF
+  ON
   BOOL
   "Whether to build supernodal SPTRSV support")
 


### PR DESCRIPTION
Ichi: turn supernodal sptrsv on by default